### PR TITLE
Add --tcp argument to dcd-client invokations to fix the 'Unable to connect socket : No such file or directory' error

### DIFF
--- a/ac-dcd.el
+++ b/ac-dcd.el
@@ -174,7 +174,7 @@ If you want to restart server, use `ac-dcd-init-server' instead."
   "Notify error with result RES and arguments ARGS."
   (let* ((errbuf (get-buffer-create ac-dcd-error-buffer-name))
          (outbuf (get-buffer ac-dcd-output-buffer-name))
-         (cmd (concat ac-dcd-executable " " (mapconcat 'identity args " ")))
+         (cmd (concat ac-dcd-executable " " (mapconcat 'identity (cons "--tcp" args) " ")))
          (errstr
           (with-current-buffer outbuf
             (goto-char (point-min))
@@ -202,7 +202,7 @@ If you want to restart server, use `ac-dcd-init-server' instead."
                     (message "ac-dcd error: could not find dcd-client executable")
                     0)
           (apply 'call-process-region (point-min) (point-max)
-                     ac-dcd-executable nil buf nil args)))
+                     ac-dcd-executable nil buf nil (cons "--tcp" args))))
     (with-current-buffer buf
       (unless (eq 0 res)
         (ac-dcd-handle-error res args))
@@ -547,7 +547,7 @@ dcd-client outputs candidates that begin with \"this\" when completing struct co
       (erase-buffer)
 
           (apply 'call-process-region (point-min) (point-max)
-                         ac-dcd-executable nil buf nil args)
+                         ac-dcd-executable nil buf nil (cons "--tcp" args))
       (when (or
              (string= (buffer-string) "")
              (string= (buffer-string) "\n\n\n")             ;when symbol has no doc
@@ -756,10 +756,10 @@ or package.json file."
         (erase-buffer)
         (if thing
             (apply 'call-process-region (point-min) (point-max)
-                   ac-dcd-executable nil buf nil (list "--search" thing))
+                   ac-dcd-executable nil buf nil (list "--tcp" "--search" thing))
           (let ((symbol (read-from-minibuffer "Enter symbol: ")))
             (apply 'call-process-region (point-min) (point-max)
-                   ac-dcd-executable nil buf nil (list "--search" symbol))))
+                   ac-dcd-executable nil buf nil (list "--tcp" "--search" symbol))))
         (display-buffer buf)
         (end-of-buffer)
         (delete-char -1)


### PR DESCRIPTION
Hi there,

I noticed that invoking dcd-client with the --port option fails as it seems recent versions of dcd require the "--tcp" option to be present as well. This PR fixes this (in a very clunky/noob way as I've not done any Lisp in more than 10 years, but this should give you an idea of what needs to be done...).

Cheers,

JB