### PR TITLE
 Fix off by one error in call to goto-char

### DIFF
--- a/ac-dcd.el
+++ b/ac-dcd.el
@@ -612,7 +612,7 @@ dcd-client outputs candidates that begin with \"this\" when completing struct co
         (ac-dcd-goto-def-push-marker)
         (unless (string=  file "stdin") ; the declaration is in the current file
           (find-file file))
-        (goto-char (byte-to-position (string-to-number offset)))))))
+        (goto-char (byte-to-position (1+ (string-to-number offset))))))))
 
 
 ;; utilities for goto-definition

--- a/ac-dcd.el
+++ b/ac-dcd.el
@@ -146,7 +146,7 @@ If you want to restart server, use `ac-dcd-init-server' instead."
 		  (prev-match ""))
 	  (while (re-search-forward pattern nil t)
 		(setq match (match-string-no-properties 1))
-		
+
 		(unless (string= "Pattern" match)
 		  (setq detailed-info (match-string-no-properties 2))
 		  (if (string= match prev-match)
@@ -233,7 +233,7 @@ TODO: multi byte character support"
   ;; I'm not sure if it is exactly 0.4. If the completion doesn't work on older dcd, please report.
   (when (> 0.4 (ac-dcd-get-version))
 	(return))
-  
+
   (let* ((end point)
   		 (begin (progn
   				  (while (not (string-match	(rx (or blank "." "\n")) (char-to-string (char-before (point)))))
@@ -344,7 +344,7 @@ When the symbol is not a function, returns nothing"
   "Regexp to parse calltip completion.
 \\1 is function return type (if exists) and name, and \\2 is args.")
 (defconst ac-dcd-template-pattern (rx (submatch (* nonl)) (submatch "(" (*? nonl) ")") (submatch "(" (* nonl)")"))
-  "Regexp to parse template calltips.  
+  "Regexp to parse template calltips.
 \\1 is function return type (if exists) and name, \\2 is template args, and \\3 is args.")
 (defconst ac-dcd-calltip-pattern
   (rx  (or (and bol (* nonl) "(" (* nonl) ")" eol)
@@ -433,7 +433,7 @@ It returns a list of calltip candidates."
 (defsubst ac-dcd-format-calltips (str)
   "Format calltips `STR' in parenthesis to yasnippet style."
   (let (yasstr)
-    
+
     ;;remove parenthesis
     (setq str (substring str 1 (- (length str) 1)))
 
@@ -462,7 +462,7 @@ This function should be called at *dcd-output* buf."
 	 res)
     (delete-region arg-beg end)
     (setq res (ac-dcd-format-calltips args))
-    
+
     (when template-beg
       (let ((template-args (buffer-substring template-beg arg-beg)))
 	(delete-region template-beg arg-beg)
@@ -535,7 +535,7 @@ dcd-client outputs candidates that begin with \"this\" when completing struct co
 (defun ac-dcd-get-ddoc ()
   "Get document with `dcd-client --doc'."
   (interactive)
-  (save-buffer)
+  ;; (save-buffer)
   (let ((args
          (append
           (ac-dcd-build-complete-args (ac-dcd-cursor-position))
@@ -603,7 +603,7 @@ dcd-client outputs candidates that begin with \"this\" when completing struct co
 (defun ac-dcd-goto-definition ()
   "Goto declaration of symbol at point."
   (interactive)
-  (save-buffer)
+  ;; (save-buffer)
   (ac-dcd-call-process-for-symbol-declaration)
   (let* ((data (ac-dcd-parse-output-for-get-symbol-declaration))
          (file (car data))

--- a/ac-dcd.el
+++ b/ac-dcd.el
@@ -586,16 +586,12 @@ dcd-client outputs candidates that begin with \"this\" when completing struct co
   "Goto the point where `ac-dcd-goto-definition' was last called."
   (interactive)
   (if (ring-empty-p ac-dcd-goto-definition-marker-ring)
-      (progn
-        (error "Marker ring is empty. Can't pop.")
-        ;; (ding)
-        )
+      (progn (message "Marker ring is empty. Can't pop.")
+             (ding))
     (let ((marker (ring-remove ac-dcd-goto-definition-marker-ring 0)))
       (switch-to-buffer (or (marker-buffer marker)
-                            (progn
-                              (error "Buffer has been deleted")
-                              ;; (ding)
-                              )))
+                            (progn (message "Buffer has been deleted")
+                                   (ding))))
       (goto-char (marker-position marker))
       ;; Cleanup the marker so as to avoid them piling up.
       (set-marker marker nil nil))))

--- a/ac-dcd.el
+++ b/ac-dcd.el
@@ -737,16 +737,17 @@ or package.json file."
 
 (defun d-eldoc-print-current-symbol-info ()
   "Return documentation string for the current D symbol."
-  (ignore-errors
-    (ac-dcd-get-ddoc)
-    (ac-dcd-reformat-document)
-    (with-current-buffer (get-buffer-create ac-dcd-document-buffer-name)
-      (propertize
-       (replace-regexp-in-string
-        "[[:space:]]*\n[[:space:]]*"
-        " "
-        (trim-string (buffer-string)))
-       'face 'font-lock-comment-face))))
+  (when nil
+    (ignore-errors
+      (ac-dcd-get-ddoc)
+      (ac-dcd-reformat-document)
+      (with-current-buffer (get-buffer-create ac-dcd-document-buffer-name)
+        (propertize
+         (replace-regexp-in-string
+          "[[:space:]]*\n[[:space:]]*"
+          " "
+          (trim-string (buffer-string)))
+         'face 'font-lock-comment-face)))))
 
 (provide 'ac-dcd)
 ;;; ac-dcd.el ends here

--- a/ac-dcd.el
+++ b/ac-dcd.el
@@ -534,6 +534,7 @@ dcd-client outputs candidates that begin with \"this\" when completing struct co
 
 (defun ac-dcd-get-ddoc ()
   "Get document with `dcd-client --doc'."
+  (interactive)
   (save-buffer)
   (let ((args
          (append
@@ -544,14 +545,17 @@ dcd-client outputs candidates that begin with \"this\" when completing struct co
 
     (with-current-buffer buf
       (erase-buffer)
-	  
+
 	  (apply 'call-process-region (point-min) (point-max)
 			 ac-dcd-executable nil buf nil args)
       (when (or
              (string= (buffer-string) "")
              (string= (buffer-string) "\n\n\n")             ;when symbol has no doc
              )
-        (error "No document for the symbol at point!"))
+        (progn
+          (error "No document for the symbol at point!")
+          ;; (ding)
+          ))
       (buffer-string)
       )))
 
@@ -582,10 +586,16 @@ dcd-client outputs candidates that begin with \"this\" when completing struct co
   "Goto the point where `ac-dcd-goto-definition' was last called."
   (interactive)
   (if (ring-empty-p ac-dcd-goto-definition-marker-ring)
-      (error "Marker ring is empty. Can't pop.")
+      (progn
+        (error "Marker ring is empty. Can't pop.")
+        ;; (ding)
+        )
     (let ((marker (ring-remove ac-dcd-goto-definition-marker-ring 0)))
       (switch-to-buffer (or (marker-buffer marker)
-                            (error "Buffer has been deleted")))
+                            (progn
+                              (error "Buffer has been deleted")
+                              ;; (ding)
+                              )))
       (goto-char (marker-position marker))
       ;; Cleanup the marker so as to avoid them piling up.
       (set-marker marker nil nil))))
@@ -714,6 +724,29 @@ or package.json file."
     (add-to-list 'popwin:special-display-config
                  `(,ac-dcd-document-buffer-name :position right :width 80))))
 
+
+;;;###autoload
+(defun d-turn-on-eldoc-mode ()
+  "Enable eldoc-mode in d-mode."
+  (interactive)
+  (set (make-local-variable 'eldoc-documentation-function)
+       'd-eldoc-print-current-symbol-info)
+  (turn-on-eldoc-mode))
+
+(add-hook 'd-mode-hook 'd-turn-on-eldoc-mode)
+
+(defun d-eldoc-print-current-symbol-info ()
+  "Return documentation string for the current D symbol."
+  (ignore-errors
+    (ac-dcd-get-ddoc)
+    (ac-dcd-reformat-document)
+    (with-current-buffer (get-buffer-create ac-dcd-document-buffer-name)
+      (propertize
+       (replace-regexp-in-string
+        "[[:space:]]*\n[[:space:]]*"
+        " "
+        (trim-string (buffer-string)))
+       'face 'font-lock-comment-face))))
 
 (provide 'ac-dcd)
 ;;; ac-dcd.el ends here


### PR DESCRIPTION
When offset is zero `(byte-to-position (string-to-number offset))` errors, otherwise (in most cases) cursor is placed one character to the left of the symbol of interest.